### PR TITLE
Bugfix: Windows Sigpipe issues

### DIFF
--- a/pmix/ppp/__init__.py
+++ b/pmix/ppp/__init__.py
@@ -17,7 +17,11 @@ Functions
 """
 import os
 from copy import copy
-from signal import signal, SIGPIPE, SIG_DFL
+try:
+    # noinspection PyUnresolvedReferences
+    from signal import signal, SIGPIPE, SIG_DFL
+except ImportError as e:
+    pass
 from itertools import product
 from collections import OrderedDict
 
@@ -78,7 +82,11 @@ def convert_file(in_file, language=None, outpath=None, **kwargs):
             try:
                 print(output)
             except BrokenPipeError:  # If output is piped.
-                signal(SIGPIPE, SIG_DFL)
+                try:
+                    signal(SIGPIPE, SIG_DFL)
+                # noinspection PyBroadException
+                except:
+                    pass
                 print(output)
     except InvalidLanguageException as err:
         if str(err):


### PR DESCRIPTION
Added Sigpipe usage within a try/except, to handle Windows use cases. Sigpipe does not seem to work very consistently, if at all, on Windows. However it is difficult to locate information on it.

This fix worked for Sam on his Windows 10 machine.